### PR TITLE
Make reverse tunnel possible through 'GatewayPorts yes'

### DIFF
--- a/sshd_config
+++ b/sshd_config
@@ -86,3 +86,8 @@ Subsystem sftp /usr/lib/openssh/sftp-server
 # PAM authentication, then enable this but set PasswordAuthentication
 # and ChallengeResponseAuthentication to 'no'.
 UsePAM yes
+
+# This allows to set reverse tunnels which is useful for selenium 
+# testing instances that then can be used by a user to test his 
+# local web server for example.
+GatewayPorts yes


### PR DESCRIPTION
Realized that https://github.com/zalando-stups/taupage/pull/71 is useless if the option it not also enabled in the odd bastion host.

As mentioned in taupage/pull/71 my use case is to run selenium in AWS through senza and being able to test my local running app in the cloud, for that I need to open an ssh -R reverse tunnel into the AWS taupage instance so the selenium browser running in there can hit my web server at port 3000 for example. Probably an alternative solution would be to setup a VPN inside the instance but that's overkill, reverse tunnel is enough I think.
