### PR TITLE
Add ec2-instance-connect to the odd image and register

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,10 @@
 FROM registry.opensource.zalan.do/stups/ubuntu:latest
-MAINTAINER Zalando SE
+LABEL maintainer="team-teapot@zalando.de"
 
 RUN apt-get update -y && apt-get install -y supervisor openssh-server psmisc python3-pip sudo netcat syslog-ng
+COPY install_eic.sh /install_eic.sh
+RUN /install_eic.sh && rm -f /install_eic.sh
+
 COPY requirements.txt /
 RUN pip3 install -r /requirements.txt
 
@@ -32,6 +35,9 @@ RUN chmod 0700 ~granting-service/.ssh
 RUN chmod 0400 ~granting-service/.ssh/authorized_keys
 
 COPY syslog-ng.conf /etc/syslog-ng.conf
+
+RUN adduser --system --disabled-login --shell /usr/sbin/nologin --no-create-home --home /nonexistent --quiet ec2-instance-connect
+RUN adduser --home /home/odd --gecos ",,," --quiet --disabled-password odd
 
 EXPOSE 22
 

--- a/install_eic.sh
+++ b/install_eic.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+set -euo pipefail
+
+VERSION="1.1.11"
+DOWNLOAD_URL="https://github.com/aws/aws-ec2-instance-connect-config/archive/${VERSION}.tar.gz"
+
+curl -L -o instance-connect.tar.gz "${DOWNLOAD_URL}"
+TEMP_DIR=$(mktemp -d)
+tar xzf instance-connect.tar.gz -C "$TEMP_DIR"
+
+for file in ${TEMP_DIR}/aws-ec2-instance-connect-config-${VERSION}/src/bin/eic_* ; do
+    chmod +x $file
+    mv $file /usr/local/bin/
+done
+
+rm -rf "${TEMP_DIR}"

--- a/run.sh
+++ b/run.sh
@@ -16,5 +16,8 @@ echo 'allowed_remote_networks: ['$ALLOWED_REMOTE_NETWORKS']' >> /etc/ssh-access-
 echo 'Writing SSH public key..'
 echo "$GRANTING_SERVICE_SSH_KEY" | sed 's/^/command="grant-ssh-access-forced-command.py" /' > ~granting-service/.ssh/authorized_keys
 
+echo 'Harvesting Host Keys for EC2 instance connect'
+/usr/local/bin/eic_harvest_hostkeys
+
 echo 'Starting Supervisor..'
 exec /usr/bin/supervisord -c /etc/supervisord.conf

--- a/sshd_config
+++ b/sshd_config
@@ -23,6 +23,8 @@ StrictModes yes
 
 PubkeyAuthentication yes
 #AuthorizedKeysFile	%h/.ssh/authorized_keys
+AuthorizedKeysCommand /usr/local/bin/eic_run_authorized_keys %u %f
+AuthorizedKeysCommandUser ec2-instance-connect
 
 # Don't read the user's ~/.rhosts and ~/.shosts files
 IgnoreRhosts yes


### PR DESCRIPTION
This PR adds the scripts from the [reference implementation](https://github.com/aws/aws-ec2-instance-connect-config/) of `ec2-instance-connect`. Also creates 2 users `odd` and `ec2-instance-connect` so that users can ssh in.